### PR TITLE
Restrict NER scanning for Python source code to comments and strings

### DIFF
--- a/pii_secret_check_hooks/check_file/base_content_check.py
+++ b/pii_secret_check_hooks/check_file/base_content_check.py
@@ -113,7 +113,7 @@ class CheckFileBase(ABC):
                         f"{filename}",
                     )
                     if self._file_changed(f):
-                        if self._issue_found_in_file_content(f):
+                        if self._issue_found_in_file_content(f, filename):
                             return True
                         else:
                             # If no issue was found, create and save file hash
@@ -154,7 +154,7 @@ class CheckFileBase(ABC):
         return found_issues
 
     # Should only be run if file content has changed
-    def _issue_found_in_file_content(self, file_object) -> bool:
+    def _issue_found_in_file_content(self, file_object, filename) -> bool:
         found_issue = False
         for i, line in enumerate(file_object):
             self.current_line_num = i + 1

--- a/pii_secret_check_hooks/check_file/ner.py
+++ b/pii_secret_check_hooks/check_file/ner.py
@@ -1,7 +1,11 @@
+import pathlib
+import tokenize
+
 import spacy
 import en_core_web_sm
 
 from pii_secret_check_hooks.config import (
+    LINE_MARKER,
     NER_IGNORE,
     NER_EXCLUDE,
 )
@@ -17,7 +21,7 @@ from pii_secret_check_hooks.check_file.base_content_check import (
 
 
 nlp = en_core_web_sm.load()
-
+PYTHON_CODE_SUFFIX = ".py"
 
 class LineUpdatedException(Exception):
     pass
@@ -44,7 +48,7 @@ class CheckForNER(CheckFileBase):
         ner_output_file=None,
     ):
         self.excluded_file_list = [] if excluded_file_list is None else excluded_file_list
-        self.excluded_ner_entity_list = [] if excluded_ner_entity_list is None else excluded_ner_entity_list
+        self.excluded_ners = set(excluded_ner_entity_list or [])
         self.ner_output_file = ner_output_file
         self.entity_list = []
 
@@ -54,16 +58,21 @@ class CheckForNER(CheckFileBase):
             excluded_file_list=self.excluded_file_list,
         )
 
+    def entity_is_suspicious(self, entity):
+        """True if this NER looks suspicious."""
+        return not (
+            (entity.label_ in NER_IGNORE)
+            or (entity.text in NER_EXCLUDE)
+            or (entity.text in self.excluded_ners)
+            or (entity.text.lower().strip() in self.excluded_ners)
+        )
+
     def line_has_issue(self, line) -> bool:
         doc = nlp(line)
         found_issue = False
         if doc.ents:
             for ent in doc.ents:
-                if (
-                    ent.label_ not in NER_IGNORE and
-                    ent.text not in NER_EXCLUDE and
-                    ent.text.lower().strip() not in self.excluded_ner_entity_list
-                ):
+                if self.entity_is_suspicious(ent):
                     print_warning(
                         f"Line {self.current_line_num}. please check '{ent.text}' - {ent.label_} - {str(spacy.explain(ent.label_))}",
                     )
@@ -72,6 +81,37 @@ class CheckForNER(CheckFileBase):
                     found_issue = True
 
         return found_issue
+
+    def _issue_found_in_python_content(self, file_object) -> bool:
+        found_issue = False
+
+        # The Python source code token and a Spacy named entity.
+        for token, entity in ner_python_scanner(file_object):
+            lineno, _ = token.start
+
+            if LINE_MARKER in token.line and self.allow_changed_lines:
+                continue
+
+            if not self.entity_is_suspicious(entity):
+                continue
+
+            found_issue = True
+            print_warning(
+                f"Line {lineno}. please check '{entity}' - {entity.label_}"
+                f" - {spacy.explain(entity.label_)}"
+            )
+            if entity.text not in self.entity_list:
+                self.entity_list.append(entity.text)
+
+        return found_issue
+
+    def _issue_found_in_file_content(self, file_object, filename) -> bool:
+        path = pathlib.Path(filename)
+
+        if path.suffix.lower() == PYTHON_CODE_SUFFIX:
+            return self._issue_found_in_python_content(file_object)
+
+        return super()._issue_found_in_file_content(file_object, filename)
 
     def after_run(self) -> None:
         if self.ner_output_file:
@@ -89,3 +129,20 @@ class CheckForNER(CheckFileBase):
         with open(self.ner_output_file, "w") as exclude_file:
             for entity in self.entity_list:
                 exclude_file.write(f"{entity}\n")
+
+
+def ner_python_scanner(fh):
+    """Yield a (token, entity) pair for each NER found in a Python source file.
+
+    Only Python strings and comments are scanned, other source text is ignored.
+    """
+    interesting_types = (tokenize.COMMENT, tokenize.STRING)
+
+    for tok in tokenize.generate_tokens(fh.readline):
+        if tok.type in interesting_types:
+            # Normalize Python comments and whitespace inside strings.
+            value = tok.string.strip().lstrip('#')
+            value = " ".join(value.split())
+
+            for ent in nlp(value).ents:
+                yield tok, ent

--- a/tests/check_file/test_base_content.py
+++ b/tests/check_file/test_base_content.py
@@ -168,7 +168,7 @@ def test_process_file_content_line_with_marker_file_changed_allow_changed_lines(
     mock = MagicMock()
     mock.__iter__.return_value = ["I am a test. #PS-IGNORE", "So am I.", ]
 
-    assert not check_base._issue_found_in_file_content(mock)
+    assert not check_base._issue_found_in_file_content(mock, "example.txt")
 
 
 def test_process_file_content_line_with_marker_file_changed_disallow_changed_lines():
@@ -182,7 +182,7 @@ def test_process_file_content_line_with_marker_file_changed_disallow_changed_lin
     mock = MagicMock()
     mock.__iter__.return_value = ["I am a test. #PS-IGNORE", "So am I.", ]
 
-    assert check_base._issue_found_in_file_content(mock)
+    assert check_base._issue_found_in_file_content(mock, "example.txt")
 
 
 def test_issue_found_in_file_creates_log_for_no_issue_files():

--- a/tests/check_file/test_ner.py
+++ b/tests/check_file/test_ner.py
@@ -1,3 +1,4 @@
+import io
 import os
 
 from pii_secret_check_hooks.check_file.ner import CheckForNER
@@ -29,3 +30,35 @@ def test_generate_ner_file():
         assert test_file.readline() == "test\n"
 
     os.remove(test_output_file_path)
+
+
+def test_ner_python_scanner_named_entity_as_variable():
+    # The PII is a Python variable, not an issue. Obviously a `Buxton` variable
+    # is bad and weird, but in practice we get false positives for _anything_
+    # that is capitalized and is not a dictionary word.
+    fh = io.StringIO("""Buxton = "The quick brown fox."\n""")
+
+    checker = CheckForNER(allow_changed_lines=True)
+    result = checker._issue_found_in_python_content(fh)
+
+    assert result == False
+
+
+def test_ner_python_scanner_named_entity_in_string():
+    # The PII is inside a Python string, it's a problem!
+    fh = io.StringIO("""foo = "Buxton."\n""")
+
+    checker = CheckForNER(allow_changed_lines=True)
+    result = checker._issue_found_in_python_content(fh)
+
+    assert result == True
+
+
+def test_ner_python_scanner_named_entity_in_comment():
+    # The PII is inside a Python comment, it's a problem!
+    fh = io.StringIO("""# Buxton\n""")
+
+    checker = CheckForNER(allow_changed_lines=True)
+    result = checker._issue_found_in_python_content(fh)
+
+    assert result == True

--- a/tests/test_pii_entrypoints.py
+++ b/tests/test_pii_entrypoints.py
@@ -46,7 +46,7 @@ def test_pii_secret_file_content_defaults(monkeypatch, process_files, get_exclud
 
 
 def test_pii_secret_file_content_ner_defaults(monkeypatch, process_files, get_excluded_filenames):
-    get_excluded_ner = mock.Mock()
+    get_excluded_ner = mock.Mock(return_value=[])
     monkeypatch.setattr(pii_secret_file_content_ner, "get_excluded_filenames", get_excluded_filenames)
     monkeypatch.setattr(pii_secret_file_content_ner, "get_excluded_ner", get_excluded_ner)
     monkeypatch.setattr(pii_secret_file_content_ner.CheckForNER, "process_files", process_files)


### PR DESCRIPTION
If a filename smells like Python, then extract the string and comment tokens
from the source and feed only those parts to the named entity recognizer,
ignoring things like Python function names.

This should reduce the number of false positives for PII in Python source code.

The `CheckFileBase` class is extended by the other checks, not just the NER
checker, but only the `CheckForNER` class needs to switch strategy for a file
depending on the filename, so I have changed the relevant method signature to
pass the filename (as well as the file content).