### PR TITLE
Less verbose logging

### DIFF
--- a/pii_secret_check_hooks/check_file/base_content_check.py
+++ b/pii_secret_check_hooks/check_file/base_content_check.py
@@ -14,17 +14,7 @@ from pii_secret_check_hooks.config import (
 from pii_secret_check_hooks.util import (
     print_error,
     print_info,
-    print_debug,
-    print_warning,
 )
-
-
-class FoundSensitiveException(Exception):
-    pass
-
-
-class LineHashChangedException(Exception):
-    pass
 
 
 class CheckFileBase(ABC):
@@ -105,11 +95,9 @@ class CheckFileBase(ABC):
             if filename not in self.excluded_file_list:
                 self.current_file = filename
                 with open(filename, "r+") as f:
-                    print_info(
-                        f"{filename}",
-                    )
                     if self._file_changed(f):
                         if self._issue_found_in_file_content(f, filename):
+                            print_info(f"{filename}")
                             return True
                         else:
                             # If no issue was found, create and save file hash
@@ -136,6 +124,9 @@ class CheckFileBase(ABC):
         log_file.close()
 
     def process_files(self, filenames) -> bool:
+        filenames = list(filenames)
+        print_info(f"Number of files for processing: {len(filenames)}")
+
         found_issues = False
 
         for filename in filenames:

--- a/pii_secret_check_hooks/check_file/file_content.py
+++ b/pii_secret_check_hooks/check_file/file_content.py
@@ -1,5 +1,4 @@
 import re
-import en_core_web_sm
 
 from rich.console import Console
 
@@ -19,12 +18,6 @@ from pii_secret_check_hooks.util import (
     print_error,
     print_warning,
 )
-
-nlp = en_core_web_sm.load()
-
-
-class LineUpdatedException(Exception):
-    pass
 
 
 console = Console()

--- a/pii_secret_check_hooks/check_file/ner.py
+++ b/pii_secret_check_hooks/check_file/ner.py
@@ -23,13 +23,6 @@ from pii_secret_check_hooks.check_file.base_content_check import (
 nlp = en_core_web_sm.load()
 PYTHON_CODE_SUFFIX = ".py"
 
-class LineUpdatedException(Exception):
-    pass
-
-
-class LineHashChangedException(Exception):
-    pass
-
 
 class CheckForNER(CheckFileBase):
     replace_lines = []


### PR DESCRIPTION
Print the filename only when an issue is found instead of always.

Also removes unused exception classes and imports.