### PR TITLE
Use append mode when writing data with `--ner_output_file`

### DIFF
--- a/pii_secret_check_hooks/check_file/base_content_check.py
+++ b/pii_secret_check_hooks/check_file/base_content_check.py
@@ -23,10 +23,6 @@ class FoundSensitiveException(Exception):
     pass
 
 
-class NoExcludeFilePassedException(Exception):
-    pass
-
-
 class LineHashChangedException(Exception):
     pass
 

--- a/pii_secret_check_hooks/check_file/file_content.py
+++ b/pii_secret_check_hooks/check_file/file_content.py
@@ -27,10 +27,6 @@ class LineUpdatedException(Exception):
     pass
 
 
-class NoExcludeFilePassedException(Exception):
-    pass
-
-
 console = Console()
 
 

--- a/pii_secret_check_hooks/check_file/ner.py
+++ b/pii_secret_check_hooks/check_file/ner.py
@@ -31,10 +31,6 @@ class LineHashChangedException(Exception):
     pass
 
 
-class NoExcludeFilePassedException(Exception):
-    pass
-
-
 class CheckForNER(CheckFileBase):
     replace_lines = []
     current_line_num = 0
@@ -120,13 +116,14 @@ class CheckForNER(CheckFileBase):
             print_info("No NER output file provided")
 
     def _generate_ner_file(self) -> None:
-        if not self.ner_output_file:
-            raise NoExcludeFilePassedException()
+        # The pre-commit hook invokes this program multiple times if there are
+        # many files. Use append mode so that we don't overwrite output from
+        # other invocations. The user is responsible for deleting the file
+        # between runs.
+        if not self.entity_list:
+            return
 
-        print_info(
-            f"Outputting NER results to NER file '{self.ner_output_file}'",
-        )
-        with open(self.ner_output_file, "w") as exclude_file:
+        with open(self.ner_output_file, "a") as exclude_file:
             for entity in self.entity_list:
                 exclude_file.write(f"{entity}\n")
 

--- a/pii_secret_check_hooks/pii_secret_file_content_ner.py
+++ b/pii_secret_check_hooks/pii_secret_file_content_ner.py
@@ -47,7 +47,7 @@ def main(argv=None):
     )
 
     if ner_output_file:
-        print_info(f"Exclude file '{ner_output_file}' provided")
+        print_info(f"NER excludes will be appended to '{ner_output_file}'")
 
     process_ner_file = CheckForNER(
         allow_changed_lines=True,

--- a/tests/check_file/test_ner.py
+++ b/tests/check_file/test_ner.py
@@ -32,6 +32,18 @@ def test_generate_ner_file():
     os.remove(test_output_file_path)
 
 
+def test_generate_ner_file_appends_content(tmp_path):
+    dest = tmp_path / "test_generate_ner_file_appends_content.txt"
+    dest.write_text("Old foo\n")
+
+    checker = CheckForNER(ner_output_file=dest)
+    checker.entity_list = ["New foo"]
+    checker._generate_ner_file()
+
+    # The new content is added on the end of the existing content.
+    assert dest.read_text() == "Old foo\nNew foo\n"
+
+
 def test_ner_python_scanner_named_entity_as_variable():
     # The PII is a Python variable, not an issue. Obviously a `Buxton` variable
     # is bad and weird, but in practice we get false positives for _anything_


### PR DESCRIPTION
Because the pre-commit hook can invoke the program multiple times, we were
overwriting NER output data when the final invocation wrote to the file.

Change to using append mode, which means NER output data from mulitple
invocations will all be kept. However this also means the program will
never truncate the file, so the user may want to do that manually.

The `NoExcludeFilePassedException` exception stuff was removed because the
regular behaviour of failing when trying to write to `None` is fine, and
there's already a guard against trying to write the NER output file with
no destination specified.

Fixes #7 .