### PR TITLE
Update __init__.py

### DIFF
--- a/pii_secret_check_hooks/__init__.py
+++ b/pii_secret_check_hooks/__init__.py
@@ -1,0 +1,4 @@
+import sys
+
+if sys.version_info < (3, 9):
+    sys.exit("pii_secret_check_hooks tool requires Python 3.9 or greater")


### PR DESCRIPTION
Refuse to run on inadequate Python version.

When run on Python < 3.9 the code currently crashes with a traceback.
This is not the way we should treat our colleagues, so this little pull request
replaces this behaviour with a message that explains what needs fixing.

This is an untested fix, so I'll download the branch and verify correct operation
before committing.