### PR TITLE
Pretty-print the JSON log data to reduce diff noise

### DIFF
--- a/pii_secret_check_hooks/check_file/base_content_check.py
+++ b/pii_secret_check_hooks/check_file/base_content_check.py
@@ -119,9 +119,9 @@ class CheckFileBase(ABC):
             return True
 
     def _write_log(self):
-        log_file = open(self.log_path, "w")
-        log_file.write(json.dumps(self.log_data))
-        log_file.close()
+        with open(self.log_path, "w") as fh:
+            # Using indent for nicer diffs when contents change.
+            json.dump(self.log_data, fh, indent=2)
 
     def process_files(self, filenames) -> bool:
         filenames = list(filenames)


### PR DESCRIPTION
With filenames and content hashes on multiple lines, any diffs will be easier
to read.

For example [this change in .pii-secret-hook/ner/pii-secret-log][1] is just 1 line, but the actual diff is waaaaaayy along the line.

This WILL result in a bogus change the first time anyone updates to a new version of pii-secret-check-hooks.

[1]: https://github.com/uktrade/data-hub-helpcentre/commit/3476c4cb49b9505b3fb5632b7c9f805bce98e7a8#diff-74f3b808ddd31c163f7d017cd573d3b6fd34c3ca59b987c2f370a25e6dfc45c1