### PR TITLE
Restore support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout repo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,19 +5,16 @@ repos:
     -   id: pii_secret_filename
         files: ''
         language: python
-        language_version: python3.9
         pass_filenames: true
         require_serial: true
     -   id: pii_secret_file_content
         files: ''
         language: python
-        language_version: python3.9
         pass_filenames: true
         require_serial: true
     -   id: pii_secret_file_content_ner
         files: ''
         language: python
-        language_version: python3.9
         # args: [--ner_output_file=ner_output_file.txt] # uncomment to output NER entities
         pass_filenames: true
         require_serial: true

--- a/pii_secret_check_hooks/__init__.py
+++ b/pii_secret_check_hooks/__init__.py
@@ -1,4 +1,4 @@
 import sys
 
-if sys.version_info < (3, 9):
-    sys.exit("pii_secret_check_hooks tool requires Python 3.9 or greater")
+if sys.version_info < (3, 7):
+    sys.exit("pii_secret_check_hooks tool requires Python 3.7 or greater")

--- a/pii_secret_check_hooks/check_file/base_content_check.py
+++ b/pii_secret_check_hooks/check_file/base_content_check.py
@@ -75,8 +75,12 @@ class CheckFileBase(ABC):
     def _file_excluded(self, filename) -> bool:
         file_path = PurePath(filename)
         for excluded_path_or_file in self.excluded_file_list:
-            if file_path.is_relative_to(excluded_path_or_file):
+            # Same as is_relative_to(..), but compatible with Python>=3.7.
+            try:
+                file_path.relative_to(excluded_path_or_file)
                 return True
+            except ValueError:
+                pass
 
         return False
 

--- a/tests/check_file/test_file_content.py
+++ b/tests/check_file/test_file_content.py
@@ -49,9 +49,7 @@ def test_pii_regex():
 def test_custom_regex_checks():
     check_file_content = CheckFileContent(
         excluded_file_list=None,
-        custom_regex_list=[
-            "dog name=(\s*)dog(\s*)name(\s*)"
-        ],
+        custom_regex_list=[r"dog name=(\s*)dog(\s*)name(\s*)"],
     )
 
     assert check_file_content._custom_regex_checks(

--- a/tox.ini
+++ b/tox.ini
@@ -3,12 +3,6 @@ envlist=py37,py38,py39
 
 [testenv]
 deps=
-    requests
-    truffleHog
-    pyyaml
-    rich
-    spacy
     pytest
-    en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.1.0/en_core_web_sm-3.1.0.tar.gz
 commands=
     pytest


### PR DESCRIPTION
Some projects use older Python versions, and devs don't have Python 3.9 setup.
This change removes the explicit requirement for Python 3.9 in the hook config.

The code was using pathlib's `is_relative_to(..)` which was added in 3.9, so
I've added the equivalent compatible code for older versions.

Tests were broken on Py 3.7 cos of `\s` in a string, so that was fixed by
marking the string as a raw string. The tests also took a super long time to
setup using tox on Py 3.7 because the dependencies were installed twice.