### PR TITLE
Bump spacy to 3.7 for python 3.12 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout repo

--- a/Pipfile
+++ b/Pipfile
@@ -14,8 +14,8 @@ pyyaml = "*"
 rich = "*"
 setuptools = "*"
 wheel = "*"
-spacy = ">=3.5.0,<3.6.0"
-en-core-web-sm = {file = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz"}
+spacy = ">=3.7.2,<3.8.0"
+en-core-web-sm = {file = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz"}
 
 [requires]
 python_version = "^3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ spacy = ">=3.7.2,<3.8.0"
 en-core-web-sm = {file = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz"}
 
 [requires]
-python_version = "^3.9"
+python_version = "^3.7"

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ spacy = ">=3.7.2,<3.8.0"
 en-core-web-sm = {file = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz"}
 
 [requires]
-python_version = "^3.7"
+python_version = "^3.9"

--- a/pii_secret_check_hooks/__init__.py
+++ b/pii_secret_check_hooks/__init__.py
@@ -1,4 +1,4 @@
 import sys
 
-if sys.version_info < (3, 7):
-    sys.exit("pii_secret_check_hooks tool requires Python 3.7 or greater")
+if sys.version_info < (3, 9):
+    sys.exit("pii_secret_check_hooks tool requires Python 3.9 or greater")

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
         "truffleHog",
         "pyyaml",
         "rich",
-        "spacy >=3.5,<3.6",
-        "en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0.tar.gz",
+        "spacy >=3.7.2,<3.8.0",
+        "en_core_web_sm@https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1.tar.gz",
     ],
     tests_require=["pytest"],
 )


### PR DESCRIPTION
This PR:
- Upgrade Spacy and associated model to above 3.7 to include python 3.12 compatibility
- Removes tests for python 3.7 and 3.8 which are no longer supported 

All tests passing locally